### PR TITLE
Make WA_APP_KEY optional to support proxy mode

### DIFF
--- a/plugins/worldbuilding/worldanvil-mcp/index.js
+++ b/plugins/worldbuilding/worldanvil-mcp/index.js
@@ -6,8 +6,10 @@
  * Provides MCP tools for interacting with the World Anvil API from Claude Code.
  *
  * Environment variables:
- *   WA_APP_KEY - World Anvil Application Key
- *   WA_AUTH_TOKEN - World Anvil User Authentication Token
+ *   WA_AUTH_TOKEN - World Anvil User Authentication Token (required)
+ *   WA_APP_KEY    - World Anvil Application Key (optional; required only for
+ *                   direct API mode. If omitted, the server uses proxy mode
+ *                   and the proxy injects the application key.)
  *
  * Changelog:
  *   v1.3.0 - Modular refactor, added Blocks/BlockFolders/Manuscripts, test infrastructure
@@ -22,12 +24,18 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createServer } from './src/server.js';
 
 // Validate environment variables
+// WA_APP_KEY is optional: omitting it enables proxy mode, where the proxy
+// injects the application key. WA_AUTH_TOKEN is always required.
 const APP_KEY = process.env.WA_APP_KEY;
 const AUTH_TOKEN = process.env.WA_AUTH_TOKEN;
 
-if (!APP_KEY || !AUTH_TOKEN) {
-  console.error('Error: WA_APP_KEY and WA_AUTH_TOKEN environment variables must be set');
+if (!AUTH_TOKEN) {
+  console.error('Error: WA_AUTH_TOKEN environment variable must be set');
   process.exit(1);
+}
+
+if (!APP_KEY) {
+  console.error('Info: WA_APP_KEY not set — running in proxy mode');
 }
 
 /**


### PR DESCRIPTION
## Summary

- The startup validation in `plugins/worldbuilding/worldanvil-mcp/index.js` previously required both `WA_APP_KEY` and `WA_AUTH_TOKEN`, causing the server to exit immediately when `APP_KEY` was absent.
- The underlying `api-client.js` already supports **proxy mode** — where a Cloudflare Worker (or similar proxy) injects the application key — when no `appKey` is provided. The hard requirement in `index.js` was blocking this valid use case.

## Changes

- `WA_AUTH_TOKEN` remains required (server exits if missing)
- `WA_APP_KEY` is now optional — if absent, the server logs an info message and runs in proxy mode
- Updated the environment variable documentation in the file header to reflect this

## Motivation

Users running a self-hosted proxy worker (which injects the `WA_APP_KEY` server-side) were unable to start the MCP server without also providing the key client-side, defeating the purpose of the proxy setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)