### PR TITLE
fix: use correct API field name 'parent' for category nesting

### DIFF
--- a/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
@@ -125,7 +125,7 @@ export async function handleToolCall(name, args, client) {
         };
         if (args.icon !== undefined) data.icon = args.icon;
         if (args.parent_category_id)
-          data.parentCategory = { id: args.parent_category_id };
+          data.parent = { id: args.parent_category_id };
         return jsonResponse(await client.createCategory(data));
       }
 
@@ -138,7 +138,7 @@ export async function handleToolCall(name, args, client) {
           data.custom1 = markdownToBBCode(args.content);
         if (args.excerpt !== undefined) data.excerpt = args.excerpt;
         if (args.parent_category_id)
-          data.parentCategory = { id: args.parent_category_id };
+          data.parent = { id: args.parent_category_id };
         return jsonResponse(
           await client.updateCategory(args.category_id, data),
         );

--- a/plugins/worldbuilding/worldanvil-mcp/test/handlers.test.js
+++ b/plugins/worldbuilding/worldanvil-mcp/test/handlers.test.js
@@ -105,10 +105,10 @@ describe("Category handlers", () => {
       );
 
       const [payload] = client.createCategory.mock.calls[0];
-      expect(payload.parentCategory).toEqual({ id: "cat-parent" });
+      expect(payload.parent).toEqual({ id: "cat-parent" });
     });
 
-    it("omits parentCategory when parent_category_id not provided", async () => {
+    it("omits parent when parent_category_id not provided", async () => {
       await handleToolCall(
         "worldanvil_create_category",
         {
@@ -119,7 +119,7 @@ describe("Category handlers", () => {
       );
 
       const [payload] = client.createCategory.mock.calls[0];
-      expect(payload.parentCategory).toBeUndefined();
+      expect(payload.parent).toBeUndefined();
     });
   });
 
@@ -136,7 +136,7 @@ describe("Category handlers", () => {
 
       expect(client.updateCategory).toHaveBeenCalledOnce();
       const [, payload] = client.updateCategory.mock.calls[0];
-      expect(payload.parentCategory).toEqual({ id: "cat-parent" });
+      expect(payload.parent).toEqual({ id: "cat-parent" });
     });
 
     it("sends only provided fields", async () => {
@@ -151,7 +151,7 @@ describe("Category handlers", () => {
 
       const [, payload] = client.updateCategory.mock.calls[0];
       expect(payload.title).toBe("Renamed");
-      expect(payload.parentCategory).toBeUndefined();
+      expect(payload.parent).toBeUndefined();
       expect(payload.icon).toBeUndefined();
     });
   });


### PR DESCRIPTION
## Problem

When calling `worldanvil_create_category` or `worldanvil_update_category`
with a `parent_category_id`, categories always ended up at the top level
regardless of the value passed.

## Expected cause

Both handlers were sending `parentCategory: { id }` in the request body.
The WorldAnvil Boromir API expects `parent: { id }` — as documented in the
official Swagger spec for [`PUT /category`](https://www.worldanvil.com/api/external/boromir/swagger-documentation#/Category/createCategory) and confirmed by the `parent` field
returned in `GET /category` responses.

The API silently ignores unknown fields, so the request returned
`success: true` but the parent was never set.

## Fix

Rename `parentCategory` → `parent` in both the `worldanvil_create_category`
and `worldanvil_update_category` handlers, and update the corresponding tests.

## Testing

All 127 unit tests pass. No live testing.