### PR TITLE
fix(marker): repair create_marker 422 + add eras, history fields, marker styling

### DIFF
--- a/plugins/worldbuilding/worldanvil-mcp/src/api-client.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/api-client.js
@@ -511,6 +511,24 @@ export class WorldAnvilClient {
     return this.request(`/timeline?id=${timelineId}`, "DELETE");
   }
 
+  // ===== ERAS =====
+
+  async getEra(eraId) {
+    return this.request(`/era?id=${eraId}&granularity=2`);
+  }
+
+  async createEra(data) {
+    return this.request("/era", "PUT", data);
+  }
+
+  async updateEra(eraId, data) {
+    return this.request(`/era?id=${eraId}`, "PATCH", data);
+  }
+
+  async deleteEra(eraId) {
+    return this.request(`/era?id=${eraId}`, "DELETE");
+  }
+
   // ===== HISTORY EVENTS =====
 
   async getHistory(historyId) {

--- a/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
@@ -353,6 +353,16 @@ export async function handleToolCall(name, args, client) {
         if (args.label_type !== undefined) data.labelType = args.label_type;
         if (args.html_marker !== undefined) data.htmlMarker = args.html_marker;
         if (args.state !== undefined) data.state = args.state;
+        if (args.circle_radius !== undefined)
+          data.circleRadius = args.circle_radius;
+        if (args.color_outline !== undefined)
+          data.colorOutline = args.color_outline;
+        if (args.color_fill !== undefined) data.colorFill = args.color_fill;
+        if (args.opacity_outline !== undefined)
+          data.opacityOutline = args.opacity_outline;
+        if (args.opacity_fill !== undefined)
+          data.opacityFill = args.opacity_fill;
+        if (args.line_weight !== undefined) data.lineWeight = args.line_weight;
         return jsonResponse(await client.createMarker(data));
       }
 
@@ -368,6 +378,16 @@ export async function handleToolCall(name, args, client) {
         if (args.label_type !== undefined) data.labelType = args.label_type;
         if (args.html_marker !== undefined) data.htmlMarker = args.html_marker;
         if (args.state !== undefined) data.state = args.state;
+        if (args.circle_radius !== undefined)
+          data.circleRadius = args.circle_radius;
+        if (args.color_outline !== undefined)
+          data.colorOutline = args.color_outline;
+        if (args.color_fill !== undefined) data.colorFill = args.color_fill;
+        if (args.opacity_outline !== undefined)
+          data.opacityOutline = args.opacity_outline;
+        if (args.opacity_fill !== undefined)
+          data.opacityFill = args.opacity_fill;
+        if (args.line_weight !== undefined) data.lineWeight = args.line_weight;
         return jsonResponse(await client.updateMarker(args.marker_id, data));
       }
 

--- a/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
@@ -339,15 +339,35 @@ export async function handleToolCall(name, args, client) {
         );
 
       case "worldanvil_create_marker": {
-        const data = { title: args.title, map: args.map_id };
-        if (args.article_id) data.article = { id: args.article_id };
+        const data = {
+          title: args.title,
+          map: { id: args.map_id },
+          world: { id: args.world_id },
+        };
+        if (args.geo_x !== undefined) data.geoX = args.geo_x;
+        if (args.geo_y !== undefined) data.geoY = args.geo_y;
+        if (args.description !== undefined) data.description = args.description;
+        if (args.article_id) data.targetArticle = { id: args.article_id };
+        if (args.group_id) data.group = { id: args.group_id };
+        if (args.label_title !== undefined) data.labelTitle = args.label_title;
+        if (args.label_type !== undefined) data.labelType = args.label_type;
+        if (args.html_marker !== undefined) data.htmlMarker = args.html_marker;
+        if (args.state !== undefined) data.state = args.state;
         return jsonResponse(await client.createMarker(data));
       }
 
       case "worldanvil_update_marker": {
         const data = {};
         if (args.title !== undefined) data.title = args.title;
-        if (args.article_id) data.article = { id: args.article_id };
+        if (args.geo_x !== undefined) data.geoX = args.geo_x;
+        if (args.geo_y !== undefined) data.geoY = args.geo_y;
+        if (args.description !== undefined) data.description = args.description;
+        if (args.article_id) data.targetArticle = { id: args.article_id };
+        if (args.group_id) data.group = { id: args.group_id };
+        if (args.label_title !== undefined) data.labelTitle = args.label_title;
+        if (args.label_type !== undefined) data.labelType = args.label_type;
+        if (args.html_marker !== undefined) data.htmlMarker = args.html_marker;
+        if (args.state !== undefined) data.state = args.state;
         return jsonResponse(await client.updateMarker(args.marker_id, data));
       }
 

--- a/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
@@ -432,6 +432,34 @@ export async function handleToolCall(name, args, client) {
       case "worldanvil_delete_timeline":
         return jsonResponse(await client.deleteTimeline(args.timeline_id));
 
+      // ===== ERAS =====
+      case "worldanvil_get_era":
+        return jsonResponse(await client.getEra(args.era_id));
+
+      case "worldanvil_create_era": {
+        const data = {
+          title: args.title,
+          timeline: { id: args.timeline_id },
+          world: { id: args.world_id },
+        };
+        if (args.year !== undefined) data.year = args.year;
+        if (args.ending_year !== undefined) data.endingYear = args.ending_year;
+        if (args.state !== undefined) data.state = args.state;
+        return jsonResponse(await client.createEra(data));
+      }
+
+      case "worldanvil_update_era": {
+        const data = {};
+        if (args.title !== undefined) data.title = args.title;
+        if (args.year !== undefined) data.year = args.year;
+        if (args.ending_year !== undefined) data.endingYear = args.ending_year;
+        if (args.state !== undefined) data.state = args.state;
+        return jsonResponse(await client.updateEra(args.era_id, data));
+      }
+
+      case "worldanvil_delete_era":
+        return jsonResponse(await client.deleteEra(args.era_id));
+
       // ===== HISTORY EVENTS =====
       case "worldanvil_get_history":
         return jsonResponse(await client.getHistory(args.history_id));

--- a/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/handlers.js
@@ -509,6 +509,13 @@ export async function handleToolCall(name, args, client) {
           data.characters = args.character_ids.map((id) => ({ id }));
         if (args.organization_ids !== undefined)
           data.organizations = args.organization_ids.map((id) => ({ id }));
+        if (args.era_id !== undefined) data.era = { id: args.era_id };
+        if (args.timeline_ids !== undefined)
+          data.timelines = args.timeline_ids.map((id) => ({ id }));
+        if (args.category !== undefined) data.category = args.category;
+        if (args.lane !== undefined) data.lane = args.lane;
+        if (args.backgroundColour !== undefined)
+          data.backgroundColour = args.backgroundColour;
         return jsonResponse(await client.createHistory(data));
       }
 
@@ -547,6 +554,13 @@ export async function handleToolCall(name, args, client) {
           data.characters = args.character_ids.map((id) => ({ id }));
         if (args.organization_ids !== undefined)
           data.organizations = args.organization_ids.map((id) => ({ id }));
+        if (args.era_id !== undefined) data.era = { id: args.era_id };
+        if (args.timeline_ids !== undefined)
+          data.timelines = args.timeline_ids.map((id) => ({ id }));
+        if (args.category !== undefined) data.category = args.category;
+        if (args.lane !== undefined) data.lane = args.lane;
+        if (args.backgroundColour !== undefined)
+          data.backgroundColour = args.backgroundColour;
         return jsonResponse(await client.updateHistory(args.history_id, data));
       }
 

--- a/plugins/worldbuilding/worldanvil-mcp/src/tools.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/tools.js
@@ -1050,6 +1050,28 @@ export function getToolDefinitions() {
             items: { type: "string" },
             description: "IDs of linked organization articles",
           },
+          era_id: {
+            type: "string",
+            description: "ID of the era this event belongs to",
+          },
+          timeline_ids: {
+            type: "array",
+            items: { type: "string" },
+            description: "IDs of timelines to attach this event to directly",
+          },
+          category: {
+            type: "string",
+            description: "Category label for the event",
+          },
+          lane: {
+            type: "integer",
+            description: "Vertical lane position on timeline view",
+          },
+          backgroundColour: {
+            type: "string",
+            description:
+              "Background colour of the event bar (hex, e.g. '#ff0000')",
+          },
         },
         required: ["title", "world_id", "year"],
       },
@@ -1129,6 +1151,28 @@ export function getToolDefinitions() {
             type: "array",
             items: { type: "string" },
             description: "IDs of linked organization articles",
+          },
+          era_id: {
+            type: "string",
+            description: "ID of the era this event belongs to",
+          },
+          timeline_ids: {
+            type: "array",
+            items: { type: "string" },
+            description: "IDs of timelines to attach this event to directly",
+          },
+          category: {
+            type: "string",
+            description: "Category label for the event",
+          },
+          lane: {
+            type: "integer",
+            description: "Vertical lane position on timeline view",
+          },
+          backgroundColour: {
+            type: "string",
+            description:
+              "Background colour of the event bar (hex, e.g. '#ff0000')",
           },
         },
         required: ["history_id"],

--- a/plugins/worldbuilding/worldanvil-mcp/src/tools.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/tools.js
@@ -686,13 +686,44 @@ export function getToolDefinitions() {
         type: "object",
         properties: {
           title: { type: "string" },
-          map_id: { type: "string" },
+          map_id: { type: "string", description: "ID of the map" },
+          world_id: {
+            type: "string",
+            description: "ID of the world (required by API)",
+          },
+          geo_x: { type: "number", description: "X coordinate on the map" },
+          geo_y: { type: "number", description: "Y coordinate on the map" },
+          description: {
+            type: "string",
+            description: "Marker description (popup body)",
+          },
           article_id: {
             type: "string",
             description: "ID of the article to link to this marker (optional)",
           },
+          group_id: {
+            type: "string",
+            description: "MarkerGroup ID (optional)",
+          },
+          label_title: {
+            type: "string",
+            description: "Custom label title shown on the marker",
+          },
+          label_type: {
+            type: "string",
+            description: "Label rendering style (e.g. 'tooltip', 'always')",
+          },
+          html_marker: {
+            type: "string",
+            description: "Custom HTML for the marker pin (advanced)",
+          },
+          state: {
+            type: "string",
+            enum: ["public", "private"],
+            description: "Visibility state",
+          },
         },
-        required: ["title", "map_id"],
+        required: ["title", "map_id", "world_id"],
       },
     },
     {
@@ -703,10 +734,21 @@ export function getToolDefinitions() {
         properties: {
           marker_id: { type: "string" },
           title: { type: "string" },
+          geo_x: { type: "number" },
+          geo_y: { type: "number" },
+          description: { type: "string" },
           article_id: {
             type: "string",
             description: "ID of the article to link to this marker (optional)",
           },
+          group_id: {
+            type: "string",
+            description: "MarkerGroup ID (optional)",
+          },
+          label_title: { type: "string" },
+          label_type: { type: "string" },
+          html_marker: { type: "string" },
+          state: { type: "string", enum: ["public", "private"] },
         },
         required: ["marker_id"],
       },

--- a/plugins/worldbuilding/worldanvil-mcp/src/tools.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/tools.js
@@ -722,6 +722,30 @@ export function getToolDefinitions() {
             enum: ["public", "private"],
             description: "Visibility state",
           },
+          circle_radius: {
+            type: "number",
+            description: "Radius for circle-style markers (pixels)",
+          },
+          color_outline: {
+            type: "string",
+            description: "Outline color (hex, e.g. '#ff0000')",
+          },
+          color_fill: {
+            type: "string",
+            description: "Fill color (hex)",
+          },
+          opacity_outline: {
+            type: "number",
+            description: "Outline opacity 0.0-1.0",
+          },
+          opacity_fill: {
+            type: "number",
+            description: "Fill opacity 0.0-1.0",
+          },
+          line_weight: {
+            type: "number",
+            description: "Outline stroke weight (pixels)",
+          },
         },
         required: ["title", "map_id", "world_id"],
       },
@@ -749,6 +773,12 @@ export function getToolDefinitions() {
           label_type: { type: "string" },
           html_marker: { type: "string" },
           state: { type: "string", enum: ["public", "private"] },
+          circle_radius: { type: "number" },
+          color_outline: { type: "string" },
+          color_fill: { type: "string" },
+          opacity_outline: { type: "number" },
+          opacity_fill: { type: "number" },
+          line_weight: { type: "number" },
         },
         required: ["marker_id"],
       },

--- a/plugins/worldbuilding/worldanvil-mcp/src/tools.js
+++ b/plugins/worldbuilding/worldanvil-mcp/src/tools.js
@@ -883,6 +883,67 @@ export function getToolDefinitions() {
       },
     },
 
+    // ===== ERAS =====
+    {
+      name: "worldanvil_get_era",
+      description: "Get era by ID",
+      inputSchema: {
+        type: "object",
+        properties: { era_id: { type: "string", description: "Era ID" } },
+        required: ["era_id"],
+      },
+    },
+    {
+      name: "worldanvil_create_era",
+      description: "Create an era on a timeline",
+      inputSchema: {
+        type: "object",
+        properties: {
+          title: { type: "string", description: "Era title" },
+          timeline_id: { type: "string", description: "Parent timeline ID" },
+          world_id: {
+            type: "string",
+            description: "World ID (required by API)",
+          },
+          year: { type: "number", description: "Starting year of the era" },
+          ending_year: {
+            type: "number",
+            description: "Ending year of the era",
+          },
+          state: {
+            type: "string",
+            enum: ["public", "private"],
+            description: "Visibility state",
+          },
+        },
+        required: ["title", "timeline_id", "world_id"],
+      },
+    },
+    {
+      name: "worldanvil_update_era",
+      description: "Update an era",
+      inputSchema: {
+        type: "object",
+        properties: {
+          era_id: { type: "string" },
+          title: { type: "string" },
+          year: { type: "number" },
+          ending_year: { type: "number" },
+          state: { type: "string", enum: ["public", "private"] },
+        },
+        required: ["era_id"],
+      },
+    },
+    {
+      name: "worldanvil_delete_era",
+      description: "Delete an era",
+      inputSchema: {
+        type: "object",
+        properties: { era_id: { type: "string" } },
+        required: ["era_id"],
+      },
+    },
+
     // ===== HISTORY EVENTS =====
     {
       name: "worldanvil_get_history",


### PR DESCRIPTION
## Summary

- **Fixes create_marker 422 in production.** `map` was sent as a bare string and `world` was omitted entirely; both must be `{ id }` references per the WA API. Adds `world_id` as a required field on `create_marker` so the omission can't recur via the MCP surface.
- **Exposes the full marker payload** on `create_marker`/`update_marker`: `geo_x`/`geo_y`, `description`, `target_article`, marker `group`, `label_title`/`label_type`, custom `html_marker`, `state`, and circle-style styling (`circle_radius`, `color_outline`, `color_fill`, `opacity_outline`, `opacity_fill`, `line_weight`).
- **Adds era CRUD** (`get_era`, `create_era`, `update_era`, `delete_era`) — timeline subdivisions previously had no MCP surface.
- **Adds 5 history-event fields** (`era_id`, `timeline_ids`, `category`, `lane`, `backgroundColour`) — most notably `era_id`, which connects history events to the new era endpoints.

Tool count goes 166 → 170. No tools removed, no breaking schema changes.

## Origin

These changes were developed against the pre-extraction monorepo (`wlcarden-plugins`) on 2026-03-31 and never made it across when the plugin was extracted to this standalone repo. The 422 bug has been in production since the extraction.

## Test plan

- [x] `node --check` clean on all three modified files
- [x] Modules load via dynamic import (`getToolDefinitions()` returns 170 tools; era tools registered; new marker/history fields present in schemas)
- [ ] Manual smoke test against a real WA world: create a marker on a map (verify no 422), create an era on a timeline, attach a history event to that era via `era_id`
- [ ] No automated tests added for the new endpoints — flagging for follow-up if test coverage is desired